### PR TITLE
Fix (unintended) race condition.

### DIFF
--- a/1CB-0-2/stringbuffer-jdk1.4/main.cpp
+++ b/1CB-0-2/stringbuffer-jdk1.4/main.cpp
@@ -23,6 +23,8 @@ int main(int argc, char *argv[]) {
     sb->append(buffer);
   //}
 
+  pthread_join(thd, NULL);
+
   return 0;
 }
 

--- a/2CS-3-31/Makefile
+++ b/2CS-3-31/Makefile
@@ -1,0 +1,8 @@
+CFLAGS := -lpthread -Wall -Werror -g3
+
+targets := $(basename $(wildcard *c))
+
+all: $(targets)
+
+clean:
+	rm -f $(targets)

--- a/2CS-3-31/account_bad.c
+++ b/2CS-3-31/account_bad.c
@@ -13,6 +13,8 @@ void *deposit(void *arg)
   balance = balance + y;
   deposit_done=1;
   pthread_mutex_unlock(&m);
+
+  return NULL;
 }
 
 void *withdraw(void *arg) 
@@ -21,6 +23,8 @@ void *withdraw(void *arg)
   balance = balance - z;
   withdraw_done=1;
   pthread_mutex_unlock(&m);
+
+  return NULL;
 }
 
 void *check_result(void *arg) 
@@ -29,6 +33,8 @@ void *check_result(void *arg)
   if (deposit_done && withdraw_done)
     assert(balance == (x - y) - z); /* BAD */
   pthread_mutex_unlock(&m);
+
+  return NULL;
 }
 
 int main() 
@@ -45,6 +51,10 @@ int main()
   pthread_create(&t3, 0, check_result, 0);
   pthread_create(&t1, 0, deposit, 0);
   pthread_create(&t2, 0, withdraw, 0);
+
+  pthread_join(t3, NULL);
+  pthread_join(t1, NULL);
+  pthread_join(t2, NULL);
 
   return 0;
 }

--- a/2CS-3-31/arithmetic_prog_bad.c
+++ b/2CS-3-31/arithmetic_prog_bad.c
@@ -30,6 +30,8 @@ void *thread1(void *arg)
 
     i++;
   }
+
+  return NULL;
 }
 
 void *thread2(void *arg)
@@ -54,6 +56,8 @@ void *thread2(void *arg)
   total=total+j;
   printf("total ....%ld\n",total);
   flag=1;
+
+  return NULL;
 }
 
 

--- a/2CS-3-31/bluetooth_driver_bad.c
+++ b/2CS-3-31/bluetooth_driver_bad.c
@@ -83,4 +83,6 @@ int main()
   pthread_create(&id, NULL, BCSP_PnpStop, &e);
   BCSP_PnpAdd(&e);
   pthread_join(id, NULL);
+
+  return 0;
 }

--- a/2CS-3-31/bluetooth_driver_bad.c
+++ b/2CS-3-31/bluetooth_driver_bad.c
@@ -1,6 +1,6 @@
 #include <pthread.h>
 #include <assert.h>
-#include "common.inc"
+//#include "common.inc"
 
 #define TRUE  (1)
 #define FALSE (0)
@@ -21,9 +21,9 @@ int BCSP_IoIncrement(DEVICE_EXTENSION *e)
   if (e->stoppingFlag)
     return -1;
 
-  __ESBMC_atomic_begin();
+  //__ESBMC_atomic_begin();
   e->pendingIo = e->pendingIo + 1;
-  __ESBMC_atomic_end();  
+  //__ESBMC_atomic_end();  
   
   return 0;
 }
@@ -32,10 +32,10 @@ void BCSP_IoDecrement(DEVICE_EXTENSION *e)
 {
   int pendingIo;
 
-  __ESBMC_atomic_begin();
+  //__ESBMC_atomic_begin();
   e->pendingIo = e->pendingIo - 1;
   pendingIo = e->pendingIo;
-  __ESBMC_atomic_end();  
+  //__ESBMC_atomic_end();  
 
   if (pendingIo == 0)
     e->stoppingEvent = TRUE;
@@ -66,9 +66,11 @@ void* BCSP_PnpStop(void* arg)
     //release allocated resource
     stopped = TRUE;
   }
+
+  return NULL;
 }
 
-void main() 
+int main() 
 {
   pthread_t id;
   DEVICE_EXTENSION e;

--- a/2CS-3-31/carter01_bad.c
+++ b/2CS-3-31/carter01_bad.c
@@ -1,5 +1,7 @@
 #include <pthread.h>
+
 pthread_mutex_t  m, l;
+
 int A = 0, B = 0;
 void *t1(void *arg) {
   pthread_mutex_lock(&m);
@@ -11,6 +13,8 @@ void *t1(void *arg) {
   A--;
   if (A == 0) pthread_mutex_unlock(&l);
   pthread_mutex_unlock(&m);
+
+  return NULL;
 }
 void *t2(void *arg) {
   pthread_mutex_lock(&m);
@@ -22,11 +26,16 @@ void *t2(void *arg) {
   B--;
   if (B == 0) pthread_mutex_unlock(&l);
   pthread_mutex_unlock(&m);
+
+  return NULL;
 }
 void *t3(void *arg) {
+  return NULL;
 }
 void *t4(void *arg) {
+  return NULL;
 }
+
 int main(void) {
   pthread_mutex_init(&m,NULL);
   pthread_mutex_init(&l,NULL);

--- a/2CS-3-31/circular_buffer_bad.c
+++ b/2CS-3-31/circular_buffer_bad.c
@@ -69,6 +69,8 @@ void *t1(void *arg)
     }
     pthread_mutex_unlock(&m);
   }  
+
+  return NULL;
 }
 
 void *t2(void *arg) 
@@ -86,6 +88,8 @@ void *t2(void *arg)
     }
     pthread_mutex_unlock(&m);
   }
+
+  return NULL;
 }
 
 int main() 

--- a/2CS-3-31/din_phil2_sat.c
+++ b/2CS-3-31/din_phil2_sat.c
@@ -1,12 +1,8 @@
 #include <pthread.h>
 #include <assert.h>
-#include "common.inc"
 
 #define N 2
 
-//void __ESBMC_atomic_begin();
-//void __ESBMC_atomic_end();
-  
 pthread_mutex_t  x[N];
 int phil;
 
@@ -20,16 +16,12 @@ void *thread1(void *arg)
   left=id;
   right=(id+1)%N;
 
-  __ESBMC_atomic_begin();
   pthread_mutex_lock(&x[right]);
   pthread_mutex_lock(&x[left]);
   pthread_mutex_unlock(&x[left]);
   pthread_mutex_unlock(&x[right]);
-  __ESBMC_atomic_end();
 
-  ++phil;
-  if (phil==N)
-    assert(0);
+  return NULL;
 }
 
 int main()

--- a/2CS-3-31/din_phil3_sat.c
+++ b/2CS-3-31/din_phil3_sat.c
@@ -1,12 +1,8 @@
 #include <pthread.h>
 #include <assert.h>
-#include "common.inc"
 
 #define N 3
 
-//void __ESBMC_atomic_begin();
-//void __ESBMC_atomic_end();
-  
 pthread_mutex_t  x[N];
 int phil;
 
@@ -20,16 +16,12 @@ void *thread1(void *arg)
   left=id;
   right=(id+1)%N;
 
-  __ESBMC_atomic_begin();
   pthread_mutex_lock(&x[right]);
   pthread_mutex_lock(&x[left]);
   pthread_mutex_unlock(&x[left]);
   pthread_mutex_unlock(&x[right]);
-  __ESBMC_atomic_end();
 
-  ++phil;
-  if (phil==N)
-    assert(0);
+  return NULL;
 }
 
 int main()

--- a/2CS-3-31/din_phil4_sat.c
+++ b/2CS-3-31/din_phil4_sat.c
@@ -1,12 +1,10 @@
 #include <pthread.h>
 #include <assert.h>
-#include "common.inc"
+
+#include <stdio.h>
 
 #define N 4
 
-//void __ESBMC_atomic_begin();
-//void __ESBMC_atomic_end();
-  
 pthread_mutex_t  x[N];
 int phil;
 
@@ -20,22 +18,20 @@ void *thread1(void *arg)
   left=id;
   right=(id+1)%N;
 
-  __ESBMC_atomic_begin();
   pthread_mutex_lock(&x[right]);
   pthread_mutex_lock(&x[left]);
   pthread_mutex_unlock(&x[left]);
   pthread_mutex_unlock(&x[right]);
-  __ESBMC_atomic_end();
 
-  ++phil;
-  if (phil==N)
-    assert(0);
+  return NULL;
 }
 
 int main()
 {
   int i;
   int arg[N];
+  phil = 0;
+
   pthread_t trd_id[N];
 
   for(i=0; i<N; i++)

--- a/2CS-3-31/din_phil5_sat.c
+++ b/2CS-3-31/din_phil5_sat.c
@@ -1,12 +1,8 @@
 #include <pthread.h>
 #include <assert.h>
-#include "common.inc"
 
 #define N 5
 
-//void __ESBMC_atomic_begin();
-//void __ESBMC_atomic_end();
-  
 pthread_mutex_t  x[N];
 int phil;
 
@@ -20,18 +16,12 @@ void *thread1(void *arg)
   left=id;
   right=(id+1)%N;
 
-  __ESBMC_atomic_begin();
   pthread_mutex_lock(&x[right]);
   pthread_mutex_lock(&x[left]);
   pthread_mutex_unlock(&x[left]);
   pthread_mutex_unlock(&x[right]);
-  __ESBMC_atomic_end();
 
-  __ESBMC_atomic_begin();
-  ++phil;
-  if (phil==N)
-    assert(0);
-  __ESBMC_atomic_end();
+  return NULL;
 }
 
 int main()

--- a/2CS-3-31/din_phil6_sat.c
+++ b/2CS-3-31/din_phil6_sat.c
@@ -1,14 +1,9 @@
 #include <pthread.h>
 #include <assert.h>
-#include "common.inc"
 
 #define N 6
 
-//void __ESBMC_atomic_begin();
-//void __ESBMC_atomic_end();
-  
 pthread_mutex_t  x[N];
-int phil;
 
 void *thread1(void *arg)
 {
@@ -20,18 +15,12 @@ void *thread1(void *arg)
   left=id;
   right=(id+1)%N;
 
-  __ESBMC_atomic_begin();
   pthread_mutex_lock(&x[right]);
   pthread_mutex_lock(&x[left]);
   pthread_mutex_unlock(&x[left]);
   pthread_mutex_unlock(&x[right]);
-  __ESBMC_atomic_end();
 
-  __ESBMC_atomic_begin();
-  ++phil;
-  if (phil==N)
-    assert(0);
-  __ESBMC_atomic_end();
+  return NULL;
 }
 
 int main()

--- a/2CS-3-31/din_phil7_sat.c
+++ b/2CS-3-31/din_phil7_sat.c
@@ -1,11 +1,7 @@
 #include <pthread.h>
 #include <assert.h>
-#include "common.inc"
 
 #define N 7
-
-//void __ESBMC_atomic_begin();
-//void __ESBMC_atomic_end();
 
 int phil;
 pthread_mutex_t  x[N];
@@ -20,18 +16,12 @@ void *thread1(void *arg)
   left=id;
   right=(id+1)%N;
 
-  __ESBMC_atomic_begin();
   pthread_mutex_lock(&x[right]);
   pthread_mutex_lock(&x[left]);
   pthread_mutex_unlock(&x[left]);
   pthread_mutex_unlock(&x[right]);
-  __ESBMC_atomic_begin();
 
-  __ESBMC_atomic_begin();
-  ++phil;
-  if (phil==N)
-    assert(0);
-  __ESBMC_atomic_end();
+  return 0;
 }
 
 int main()
@@ -54,4 +44,3 @@ int main()
 
   return 0;
 }
-

--- a/2CS-3-31/lazy01_bad.c
+++ b/2CS-3-31/lazy01_bad.c
@@ -9,6 +9,8 @@ void *thread1(void *arg)
   pthread_mutex_lock(&mutex);
   data++;
   pthread_mutex_unlock(&mutex);
+
+  return NULL;
 }
 
 
@@ -17,6 +19,8 @@ void *thread2(void *arg)
   pthread_mutex_lock(&mutex);
   data+=2;
   pthread_mutex_unlock(&mutex);
+
+  return NULL;
 }
 
 
@@ -27,6 +31,8 @@ void *thread3(void *arg)
     assert(0); /* BAD */
   }
   pthread_mutex_unlock(&mutex);    
+
+  return NULL;
 }
 
 

--- a/2CS-3-31/phase01_bad.c
+++ b/2CS-3-31/phase01_bad.c
@@ -13,6 +13,8 @@ void *thread1(void *arg)
   pthread_mutex_unlock(&y);
   pthread_mutex_lock(&y);
   pthread_mutex_unlock(&y);
+
+  return NULL;
 }
 
 

--- a/2CS-3-31/queue_bad.c
+++ b/2CS-3-31/queue_bad.c
@@ -21,7 +21,7 @@ int stored_elements[SIZE];
 _Bool enqueue_flag, dequeue_flag;
 QType queue;
 
-int init(QType *q) 
+void init(QType *q) 
 {
   q->head=0;
   q->tail=0;

--- a/2CS-3-31/stack_bad.c
+++ b/2CS-3-31/stack_bad.c
@@ -29,10 +29,12 @@ int get_top(void)
   return top;
 }
 
+#if 0
 int stack_empty(void)
 {
   (top==0) ? TRUE : FALSE; 
 }
+#endif
 
 int push(unsigned int *stack, int x)
 {
@@ -75,6 +77,8 @@ void *t1(void *arg)
     flag=TRUE;
     pthread_mutex_unlock(&m);
   }
+
+  return NULL;
 }
 
 void *t2(void *arg) 
@@ -88,6 +92,8 @@ void *t2(void *arg)
       assert(pop(arr)!=UNDERFLOW); /* BAD */
     pthread_mutex_unlock(&m);
   }
+
+  return NULL;
 }
 
 

--- a/2CS-3-31/sync01_bad.c
+++ b/2CS-3-31/sync01_bad.c
@@ -20,6 +20,8 @@ void * thread1(void * arg)
 
   pthread_mutex_unlock(&m);
   pthread_cond_signal(&full);
+
+  return NULL;
 }
 
 
@@ -38,6 +40,8 @@ void * thread2(void * arg)
 
   pthread_cond_signal(&empty);
 #endif
+
+  return NULL;
 }
 
 

--- a/2CS-3-31/sync02_bad.c
+++ b/2CS-3-31/sync02_bad.c
@@ -7,24 +7,33 @@ void* producer(void* arg) {
   int i = 0;
   while (i < N) {
     pthread_mutex_lock(&m);
-    while (num > 0) 
+    while (num > 0) {
       pthread_cond_wait(&empty, &m);        
+    }
     num++; //produce
     pthread_mutex_unlock(&m);
     pthread_cond_signal(&full);
     i++;
-} }
+  } 
+
+  return NULL;
+}
 void* consumer(void* arg) {
   int j = 0;
   while (j < N){
     pthread_mutex_lock(&m);
-    while (num == 0) 
+    while (num == 0) {
       pthread_cond_wait(&full, &m);    
+    }
     num--; //consume
     pthread_mutex_unlock(&m);    
     pthread_cond_signal(&empty);
     j++;    
-} } 
+  }
+
+  return NULL;
+}
+
 int main() {
   pthread_t  id1, id2;
   num = 2;

--- a/2CS-3-31/token_ring_bad.c
+++ b/2CS-3-31/token_ring_bad.c
@@ -1,6 +1,6 @@
 #include <pthread.h>
 #include <assert.h>
-#include "common.inc"
+//#include "common.inc"
 
 int x1 = 1;
 int x2 = 2;
@@ -13,34 +13,42 @@ _Bool flag1=0, flag2=0, flag3=0;
 
 void *t1(void *arg)
 {
-  __ESBMC_atomic_begin();
+  //__ESBMC_atomic_begin();
     x1 = (x3+1)%4;
   flag1=1;
-  __ESBMC_atomic_end();
+  //__ESBMC_atomic_end();
+  
+  return NULL;
 }
 
 void *t2(void *arg)
 {
-  __ESBMC_atomic_begin();
+  //__ESBMC_atomic_begin();
     x2 = x1;
   flag2=1;
-  __ESBMC_atomic_end();
+  //__ESBMC_atomic_end();
+  
+  return NULL;
 }
 
 void *t3(void *arg)
 {
-  __ESBMC_atomic_begin();
+  //__ESBMC_atomic_begin();
     x3 = x2;
   flag3=1;
-  __ESBMC_atomic_end();
+  //__ESBMC_atomic_end();
+
+  return NULL;
 }
 
 void *t4(void *arg)
 {
-  __ESBMC_atomic_begin();
+  //__ESBMC_atomic_begin();
   if (flag1 && flag2 && flag3)
     assert(x1 == x2 && x2 == x3); /* BAD */
-  __ESBMC_atomic_end();
+  //__ESBMC_atomic_end();
+
+  return NULL;
 }
 
 int main()
@@ -50,7 +58,12 @@ int main()
   pthread_create(&id1, NULL, t1, NULL);
   pthread_create(&id2, NULL, t2, NULL);
   pthread_create(&id3, NULL, t3, NULL);
-  pthread_create(&id3, NULL, t4, NULL);
+  pthread_create(&id4, NULL, t4, NULL);
+
+  pthread_join(id1, NULL);
+  pthread_join(id2, NULL);
+  pthread_join(id3, NULL);
+  pthread_join(id4, NULL);
 
   return 0;
 }


### PR DESCRIPTION
Because return 0 is used in main, there is a chance that the spawned
thread in main has not finished before return 0 is called. When main
returns, the process exits. This causes the spawned thread to exit
resulting in there being 0 chance for the bug occurring.

By the way, thank you for publicly releasing these benchmarks!

Markus Kusano
